### PR TITLE
fix: changed pt2ms to also support multiple tile rects

### DIFF
--- a/osr/mm2ms.simba
+++ b/osr/mm2ms.simba
@@ -200,14 +200,14 @@ end;
 
 
 (*
-Minimap.VecToMsRect()
-~~~~~~~~~~~~~~~~~~~~~
+Minimap.VecToMsRect
+~~~~~~~~~~~~~~~~~~~
 .. pascal:: function TRSMinimap.VecToMsRect(Vec: Vector3; WESize, NSSize: Double = 1; Roll:Single=$FFFF): TRectangle;
 
 Takes a single coordinate as a Vector3 on the minimap, and converts it to a rectangle / tile on the mainscreen.
 
-*WESize* is the size of the rectangle we want to get from west-to-east.
-*NSSize* is the size of the rectangle we want to get from north-to-south.
+*WESize* is the size of the rectangle we want to get from west-to-east measured in RS tiles.
+*NSSize* is the size of the rectangle we want to get from north-to-south measured in RS tiles.
 
 By default this values are 1 which will return you one single tile.
 If you wanted to get the tiles of a runecrafting altar for example which is 3 by 3 tiles you would set both to 3.
@@ -237,7 +237,6 @@ begin
   Result := [Arr[0], Arr[1], Arr[2], Arr[3]];
 end;
 
-
 (*
 Minimap.PointToMsRect
 ~~~~~~~~~~~~~~~~~~~~~
@@ -245,57 +244,35 @@ Minimap.PointToMsRect
 
 Takes a single coordinate as a TPoint on the minimap, and converts it to a rectangle / tile on the mainscreen.
 
-*ROLL is the compass angle, by leaving it default it will gather the compass angle itself.*
-*)
-function TRSMinimap.PointToMsRect(PT: TPoint; Roll:Single=$FFFF): TRectangle;
-var
-  arr: TPointArray;
-begin
-  if (Roll = $FFFF) then Roll := Self.GetCompassAngle(False);
-  pt := pt.Rotate(PI*2 - Roll, Point(Minimap.Center.X, Minimap.Center.Y));
-  
-  Arr := MM2MS.Run([Vec3(PT.x-2, PT.y-2), Vec3(PT.x+2, PT.y-2), Vec3(PT.x+2, PT.y+2), Vec3(PT.x-2, PT.y+2)], Roll);
-  Result := [Arr[0], Arr[1], Arr[2], Arr[3]];
-end;
+*WESize* is the size of the rectangle we want to get from west-to-east measured in RS tiles.
+*NSSize* is the size of the rectangle we want to get from north-to-south measured in RS tiles.
 
-(*
-Minimap.VecToMsBox
-~~~~~~~~~~~~~~~~~~
-.. pascal:: function TRSMinimap.VecToMsBox(Vec: Vector3; Roll:Single=$FFFF): TBox;
-
-Takes a single coordinate as a Vector3 on the minimap, and converts it to a rough box on the mainscreen.
+By default this values are 1 which will return you one single tile.
+If you wanted to get the tiles of a runecrafting altar for example which is 3 by 3 tiles you would set both to 3.
 
 *ROLL is the compass angle, by leaving it default it will gather the compass angle itself.*
 *)
-function TRSMinimap.VecToMsBox(Vec: Vector3; Roll:Single=$FFFF): TBox;
+function TRSMinimap.PointToMsRect(PT: TPoint; WESize, NSSize: Double = 1; Roll:Single=$FFFF): TRectangle;
 var
-  arr: TPointArray;
+  Arr: TPointArray;
 begin
+  if WESize <= 0 then WESize := 1;
+  if NSSize <= 0 then NSSize := 1;
+
+  //tiles are roughly 4 pixels height and width in the minimap.
+  //so for our coordinate we will want to "expand" each tile 2 pixels north, south, east and west.
+  WESize := 2 * WESize;
+  NSSize := 2 * NSSize;
+
   if (Roll = $FFFF) then Roll := Self.GetCompassAngle(False);
-  Vec := Vec.RotateXY(PI*2 - Roll, Minimap.Center.X, Minimap.Center.Y);
 
-  Arr := MM2MS.Run([Vec3(Vec.x-2, Vec.y-2, Vec.z), Vec3(Vec.x+2, Vec.y-2, Vec.z), Vec3(Vec.x+2, Vec.y+2, Vec.z), Vec3(Vec.x-2, Vec.y+2, Vec.z)], Roll);
-  Result := GetTPABounds(arr);
-end;
-
-(*
-Minimap.VecToMsBox
-~~~~~~~~~~~~~~~~~~
-.. pascal:: function TRSMinimap.PointToMsBox(PT: TPoint; Roll:Single=$FFFF): TBox;
-
-Takes a single coordinate as a TPoint on the minimap, and converts it to a rough box on the mainscreen.
-
-*ROLL is the compass angle, by leaving it default it will gather the compass angle itself.*
-*)
-function TRSMinimap.PointToMsBox(PT: TPoint; Roll:Single=$FFFF): TBox;
-var
-  arr: TPointArray;
-begin
-  if (Roll = $FFFF) then Roll := Self.GetCompassAngle(False);
   PT := PT.Rotate(PI*2 - Roll, Point(Minimap.Center.X, Minimap.Center.Y));
-
-  Arr := MM2MS.Run([Vec3(PT.x-2, PT.y-2), Vec3(PT.x+2, PT.y-2), Vec3(PT.x+2, PT.y+2), Vec3(PT.x-2, PT.y+2)], Roll);
-  Result := GetTPABounds(arr);
+  
+  Arr := MM2MS.Run([Vec3(PT.x-WESize, PT.y-NSSize),
+                    Vec3(PT.x+WESize, PT.y-NSSize),
+                    Vec3(PT.x+WESize, PT.y+NSSize),
+                    Vec3(PT.x-WESize, PT.y+NSSize)], Roll);
+  Result := [Arr[0], Arr[1], Arr[2], Arr[3]];
 end;
 
 (*
@@ -305,14 +282,17 @@ Minimap.StaticToMsRect
 
 Takes static minimap coordinate, rotates it to compass angle, and returns a rectangle on the mainscreen
 The static point is therefor gathered at north, and it will rotate it as expected.
+
+*WESize* is the size of the rectangle we want to get from west-to-east measured in RS tiles.
+*NSSize* is the size of the rectangle we want to get from north-to-south measured in RS tiles.
 *)
-function TRSMinimap.StaticToMsRect(StaticMMPoint: TPoint; Height:Int32=0): TRectangle;
+function TRSMinimap.StaticToMsRect(StaticMMPoint: TPoint; WESize, NSSize: Double = 1; Height: Double = 0): TRectangle;
 var
-  angle: Double;
+  Angle: Double;
 begin
-  angle := Minimap.GetCompassAngle(False);
-  with StaticMMPoint.Rotate(angle, Point(Minimap.Center.X, Minimap.Center.Y)) do
-    Result := Minimap.VecToMSRect(Vec3(X,Y, Height), 1, 1, angle);
+  Angle  := Minimap.GetCompassAngle(False);
+  with StaticMMPoint.Rotate(Angle, Minimap.Center) do
+    Result := Minimap.VecToMSRect(Vec3(X, Y, Height), WESize, NSSize, Angle);
 end;
 
 (*
@@ -380,7 +360,7 @@ end;
 
 (*
 Mainscreen
--------------------------------------------------------
+----------
 Extend the mainscreen-functionality with MS2MM function
 *)
 

--- a/osr/walker/walker.simba
+++ b/osr/walker/walker.simba
@@ -936,20 +936,21 @@ begin
   UnFreeze();
 end;
 
-function TRSWalker.GetTileMSEx(Me, Loc: TPoint; Height:Double=0; Offx,Offy:Double=0): TRectangle;
+function TRSWalker.GetTileMSEx(Me, Loc: TPoint; WESize, NESize: Double = 1; Height:Double=0; Offx,Offy:Double=0): TRectangle;
 var
   angle: Double;
 begin
   Loc   := Minimap.Center + (Loc - Me);
   angle := Minimap.GetCompassAngle(False);
   Loc   := Loc.Rotate(angle, Minimap.Center);
-  Result := Minimap.VecToMSRect(Vec3(Loc.x - offx, Loc.y - offy, Height), angle);
+  Result := Minimap.VecToMSRect(Vec3(Loc.x - offx, Loc.y - offy, Height), 1, 1, angle);
 end;
 
-function TRSWalker.GetTileMS(Loc: TPoint; Height:Double=0; Offx,Offy:Double=0): TRectangle;
+function TRSWalker.GetTileMS(Loc: TPoint; WESize, NESize: Double = 1; Height:Double=0; Offx,Offy:Double=0): TRectangle;
 begin
-  Result := Self.GetTileMSEx(Self.GetMyPos(), Loc, Height, Offx, Offy);
+  Result := Self.GetTileMSEx(Self.GetMyPos(), Loc, WESize, NESize, Height, Offx, Offy);
 end;
+
 
 function TRSWalker.MSToWorldEx(Me, Loc: TPoint; Height: Int32 = 0; Accuracy: Double = 0.2): TPoint;
 begin

--- a/osr/walker/walker.simba
+++ b/osr/walker/walker.simba
@@ -936,16 +936,53 @@ begin
   UnFreeze();
 end;
 
+(*
+TRSWalker.GetTileMSEx
+~~~~~~~~~~~~~~~~~~~~~
+.. pascal:: function TRSWalker.GetTileMSEx(Me, Loc: TPoint; WESize, NESize: Double = 1; Height:Double=0; Offx,Offy:Double=0): TRectangle;
+
+Used to convert a coordinate in our map to a tile on the mainscreen relative to the position passed in to **Me**.
+This can be used to predict location of things before hand by passing in our future position or the current location by passing in TRSWalker.GetMyPos().
+
+Example
+-------
+
+  MyTile := [100, 100];
+  Debug(Walker.GetTileMSEx(Walker.GetMyPos(), MyTile));
+*)
 function TRSWalker.GetTileMSEx(Me, Loc: TPoint; WESize, NESize: Double = 1; Height:Double=0; Offx,Offy:Double=0): TRectangle;
 var
   angle: Double;
 begin
   Loc   := Minimap.Center + (Loc - Me);
+
+  //This prevents users running out of memory from fetching tiles too far away.
+  //Everything at the very edge of the minimap is also roughly the same limit of the render distance.
+  //So even though we could fetch tiles further that are visible they would be pitch black because they are not rendered and kind of pointless.
+  //So this just won't go further if the point is not on the minimap and prevents users from accidentally trying to get tiles that are truly too far.
+  if not Minimap.IsPointOn(Loc) then
+    Exit;
+
+
   angle := Minimap.GetCompassAngle(False);
   Loc   := Loc.Rotate(angle, Minimap.Center);
-  Result := Minimap.VecToMSRect(Vec3(Loc.x - offx, Loc.y - offy, Height), 1, 1, angle);
+  Result := Minimap.VecToMSRect(Vec3(Loc.x - offx, Loc.y - offy, Height), WESize, NESize, angle);
 end;
 
+(*
+TRSWalker.GetTileMS
+~~~~~~~~~~~~~~~~~~~
+.. pascal:: function TRSWalker.GetTileMSEx(Me, Loc: TPoint; WESize, NESize: Double = 1; Height:Double=0; Offx,Offy:Double=0): TRectangle;
+
+Method to convert a coordinate in our map to a tile on the mainscreen without the need to pass in our position.
+This calls TRSWalker.GetTileMSEx internally with TRSWalker.GetMyPos() passed in.
+
+Example
+-------
+
+  MyTile := [100, 100];
+  Debug(Walker.GetTileMS(MyTile));
+*)
 function TRSWalker.GetTileMS(Loc: TPoint; WESize, NESize: Double = 1; Height:Double=0; Offx,Offy:Double=0): TRectangle;
 begin
   Result := Self.GetTileMSEx(Self.GetMyPos(), Loc, WESize, NESize, Height, Offx, Offy);


### PR DESCRIPTION
I also fixed some issues in `TRSWalker.GetTileMSEx` and `TRSWalker.GetTileMS` due to the recent changes.
But I would like to know you guys opinion on something...
For WaspLib, to handle tiles with a "SWSize", "NSSize", "Height" I've decided to use a record for that since it seemed easier to me than passing in 3 doubles. I would like to do the same in SRL if you guys agree with it.

I ended up using a Vector3 instead since it was an already existing record that could be used for this:
```pascal
function TRSWalker.GetTileMS(Me, Loc: TPoint; TileVector: Vector3; Offset: TPoint = [0, 0]): TRectangle; overload;
var
  Angle: Double;
begin
  Loc := Minimap.Center + (Loc - Me);
  if not Minimap.IsPointOn(Loc) then Exit;

  Angle  := Minimap.GetCompassAngle(False);
  Loc    := Loc.Rotate(Angle, Minimap.Center);
  Result := Minimap.VecToMSRect(
                Vec3(Loc.X - Offset.X, Loc.Y - Offset.Y, TileVector.Z),
                TileVector.X, TileVector.Y, Angle);
end;
````

I've also just realized that by turning `Offset `into a `TPoint` I lost the accuracy of the doubles, so it could become a `Vector2` instead.

Either way it's not a big deal, just personal preference.