### PR TITLE
MM2MS.ZoomLevel

### DIFF
--- a/osr/mm2ms.simba
+++ b/osr/mm2ms.simba
@@ -588,17 +588,20 @@ begin
 end;
 
 (*
-Options.SetZoomLevel
+Options.GetZoomLevel
 ~~~~~~~~~~~~~~~~~~~~
-.. pascal:: function TRSOptions.SetZoomLevel(Level: Int32): Boolean; override;
+.. pascal:: function TRSOptions.GetZoomLevel(): Int32; override;
 
 Override to automatically update MM2MS.ZoomLevel.
+
+TRSOptions.GetZoomLevel() is called when setting the result for TRSOptions.SetZoomLevel() so this should always
+keep MM2MS.ZoomLevel up to date.
 *)
-function TRSOptions.SetZoomLevel(Level: Int32): Boolean; override;
+function TRSOptions.GetZoomLevel(): Int32; override;
 begin
   Result := inherited();
-  if Result then
-    MM2MS.ZoomLevel := Level;
+  if Result > -1 then          //Only set MM2MS.ZoomLevel if we managed to read it.
+    MM2MS.ZoomLevel := Result;
 end;
 
 begin

--- a/osr/options.simba
+++ b/osr/options.simba
@@ -180,7 +180,7 @@ begin
     MOUSE_LEFT
   );
 
-  Result := WaitUntil(Self.GetZoomLevel() = Level, SRL.TruncatedGauss(50, 1500), 3000);
+  Result := WaitUntil(InRange(Self.GetZoomLevel(), Level-1, Level+1), SRL.TruncatedGauss(50, 1500), 3000);
 end;
 
 (*


### PR DESCRIPTION
Read the commit messages for more info.

In a nutshell, MM2MS.ZoomLevel would become stale sometimes if `Options.SetZoomLevel()` failed to set the zoom level but changed the level we were at anyway.

A simple test that I run to figure it out was posted on my discord.