### PR TITLE
TRSWalker1500 backport

### DIFF
--- a/osr/inventory.simba
+++ b/osr/inventory.simba
@@ -773,14 +773,16 @@ begin
 end;
 
 
-function TRSInventory.FindItems(Items: TRSItemArray): Boolean; overload; deprecated 'Use TRSInventory.ContainsAll()';
+//DEPRECATED! AVOID USING THIS
+function TRSInventory.FindItems(Items: TRSItemArray): Boolean; overload;
 var
   Slots: TIntegerArray;
 begin
   Result := Self.FindItems(Items, Slots);
 end;
 
-function TRSInventory.FindItem(Item: TRSItem): Boolean; overload; deprecated 'Use TRSInventory.ContainsItem()';
+//DEPRECATED! AVOID USING THIS
+function TRSInventory.FindItem(Item: TRSItem): Boolean; overload;
 var
   Slots: TIntegerArray;
 begin
@@ -788,19 +790,7 @@ begin
 end;
 
 
-(*
-Inventory.CountItem
-~~~~~~~~~~~~~~~~~~~
-.. pascal:: function TRSInventory.CountItem(Item: TRSItem): Int32;
 
-Returns the amount of **Item** in the inventory.
-Keep in mind this does not count a stack number, but every single item that occupies an inventory slot.
-
-Example
--------
-
-  WriteLn Inventory.CountItem('Shark');
-*)
 function TRSInventory.CountItem(Item: TRSItem): Int32;
 var
   Slots: TIntegerArray;
@@ -809,19 +799,6 @@ begin
     Result := Length(Slots);
 end;
 
-(*
-Inventory.CountItemStack
-~~~~~~~~~~~~~~~~~~~~~~~~
-.. pascal:: function TRSInventory.CountItemStack(Item: TRSItem): Int32;
-
-Returns the stack amount of **Item** in the inventory.
-
-Example
--------
-
-  WriteLn Inventory.CountItemStack('Bronze arrows'); //will print the stack amount
-  WriteLn Inventory.CountItemStack('Shark'); //will print 0 because sharks are not stackable.
-*)
 function TRSInventory.CountItemStack(Item: TRSItem): Int32;
 var
   Slot: Int32;
@@ -830,20 +807,6 @@ begin
     Result := SRL.GetItemAmount(Self.GetSlotBox(Slot));
 end;
 
-
-(*
-Inventory.HoverItem
-~~~~~~~~~~~~~~~~~~~
-.. pascal:: function TRSInventory.HoverItem(Item: TRSItem): Boolean;
-
-Hover **Item** in the inventory.
-
-Example
--------
-
-  if Inventory.HoverItem('Bronze arrows') then
-    ChooseOption.Select('Drop');
-*)
 function TRSInventory.HoverItem(Item: TRSItem): Boolean;
 var
   Slot: Int32;
@@ -853,20 +816,6 @@ begin
     Mouse.Move(Self.GetSlotBox(Slot));
 end;
 
-(*
-Inventory.ClickItem
-~~~~~~~~~~~~~~~~~~~
-.. pascal:: function TRSInventory.ClickItem(Item: TRSItem; Option: String = ''): Boolean;
-
-Clicks **Item** in the inventory. If **Option** is specified that option will be
-selected with right click if it exists.
-
-Example
--------
-
-  WriteLn Inventory.ClickItem('Attack potion(3)');
-  WriteLn Inventory.ClickItem('Ashes', 'Drop');
-*)
 function TRSInventory.ClickItem(Item: TRSItem; Option: String = ''): Boolean;
 begin
   if Self.HoverItem(Item) then
@@ -882,18 +831,6 @@ begin
   end;
 end;
 
-(*
-Inventory.Use
-~~~~~~~~~~~~~
-.. pascal:: function TRSInventory.Use(Item, OtherItem: TRSItem): Boolean; overload;
-
-Use one item on another
-
-Example
--------
-
-  WriteLn Inventory.Use('Knife', 'Oak logs');
-*)
 function TRSInventory.Use(Item, OtherItem: TRSItem): Boolean; overload;
 var
   Slots, OtherSlots: TIntegerArray;

--- a/osr/inventory.simba
+++ b/osr/inventory.simba
@@ -773,16 +773,14 @@ begin
 end;
 
 
-//DEPRECATED! AVOID USING THIS
-function TRSInventory.FindItems(Items: TRSItemArray): Boolean; overload;
+function TRSInventory.FindItems(Items: TRSItemArray): Boolean; overload; deprecated 'Use TRSInventory.ContainsAll()';
 var
   Slots: TIntegerArray;
 begin
   Result := Self.FindItems(Items, Slots);
 end;
 
-//DEPRECATED! AVOID USING THIS
-function TRSInventory.FindItem(Item: TRSItem): Boolean; overload;
+function TRSInventory.FindItem(Item: TRSItem): Boolean; overload; deprecated 'Use TRSInventory.ContainsItem()';
 var
   Slots: TIntegerArray;
 begin
@@ -790,7 +788,19 @@ begin
 end;
 
 
+(*
+Inventory.CountItem
+~~~~~~~~~~~~~~~~~~~
+.. pascal:: function TRSInventory.CountItem(Item: TRSItem): Int32;
 
+Returns the amount of **Item** in the inventory.
+Keep in mind this does not count a stack number, but every single item that occupies an inventory slot.
+
+Example
+-------
+
+  WriteLn Inventory.CountItem('Shark');
+*)
 function TRSInventory.CountItem(Item: TRSItem): Int32;
 var
   Slots: TIntegerArray;
@@ -799,6 +809,19 @@ begin
     Result := Length(Slots);
 end;
 
+(*
+Inventory.CountItemStack
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. pascal:: function TRSInventory.CountItemStack(Item: TRSItem): Int32;
+
+Returns the stack amount of **Item** in the inventory.
+
+Example
+-------
+
+  WriteLn Inventory.CountItemStack('Bronze arrows'); //will print the stack amount
+  WriteLn Inventory.CountItemStack('Shark'); //will print 0 because sharks are not stackable.
+*)
 function TRSInventory.CountItemStack(Item: TRSItem): Int32;
 var
   Slot: Int32;
@@ -807,6 +830,20 @@ begin
     Result := SRL.GetItemAmount(Self.GetSlotBox(Slot));
 end;
 
+
+(*
+Inventory.HoverItem
+~~~~~~~~~~~~~~~~~~~
+.. pascal:: function TRSInventory.HoverItem(Item: TRSItem): Boolean;
+
+Hover **Item** in the inventory.
+
+Example
+-------
+
+  if Inventory.HoverItem('Bronze arrows') then
+    ChooseOption.Select('Drop');
+*)
 function TRSInventory.HoverItem(Item: TRSItem): Boolean;
 var
   Slot: Int32;
@@ -816,6 +853,20 @@ begin
     Mouse.Move(Self.GetSlotBox(Slot));
 end;
 
+(*
+Inventory.ClickItem
+~~~~~~~~~~~~~~~~~~~
+.. pascal:: function TRSInventory.ClickItem(Item: TRSItem; Option: String = ''): Boolean;
+
+Clicks **Item** in the inventory. If **Option** is specified that option will be
+selected with right click if it exists.
+
+Example
+-------
+
+  WriteLn Inventory.ClickItem('Attack potion(3)');
+  WriteLn Inventory.ClickItem('Ashes', 'Drop');
+*)
 function TRSInventory.ClickItem(Item: TRSItem; Option: String = ''): Boolean;
 begin
   if Self.HoverItem(Item) then
@@ -831,6 +882,18 @@ begin
   end;
 end;
 
+(*
+Inventory.Use
+~~~~~~~~~~~~~
+.. pascal:: function TRSInventory.Use(Item, OtherItem: TRSItem): Boolean; overload;
+
+Use one item on another
+
+Example
+-------
+
+  WriteLn Inventory.Use('Knife', 'Oak logs');
+*)
 function TRSInventory.Use(Item, OtherItem: TRSItem): Boolean; overload;
 var
   Slots, OtherSlots: TIntegerArray;

--- a/osr/xpbar.simba
+++ b/osr/xpbar.simba
@@ -1,77 +1,38 @@
+(*
+XPBar
+=====
+Methods to interact with the XP bar.
+*)
 {$DEFINE SRL_XPBAR_INCLUDED}
 {$IFNDEF SRL_OSR}
   {$I SRL/osr.simba}
 {$ENDIF}
 
 type
-  ERSXPBarLocation = (LEFT, MIDDLE, RIGHT);
-  ERSXPBarSize = (SMALL, MEDIUM, LARGE);
-
   TRSXPBar = record(TRSInterface)
-    Alignments: array[ERSXPBarLocation] of array[ERSXPBarSize] of TRSInterfaceAlignment;
+    Alignments: array of TRSInterfaceAlignment;
     Font: TFontSet;
+    IsSetup: Boolean;
   end;
 
-procedure TRSXPBar.Setup; override;
+(*
+XPBar.Setup
+~~~~~~~~~~~
+.. pascal:: procedure TRSXPBar.Setup(); override;
+
+Initializes **XPBar** variables.
+
+.. note:: This is automatically called on the **XPBar** variable.
+*)
+procedure TRSXPBar.Setup(); override;
 begin
   inherited;
 
   Self.Name := 'XPBar';
 
-  // Small Text
-  with Self.Alignments[ERSXPBarLocation.LEFT][ERSXPBarSize.SMALL] do
-  begin
-    Left := [@InterfaceArea.X1, 2];
-    Right := [@InterfaceArea.X1, 120];
-    Top := [@InterfaceArea.Y1, 23];
-    Bottom := [@InterfaceArea.Y1, 51];
-  end;
+  SetLength(Self.Alignments, 3);
 
-  with Self.Alignments[ERSXPBarLocation.MIDDLE][ERSXPBarSize.SMALL] do
-  begin
-    Left   := [@InterfaceArea.X1];
-    Right  := [@InterfaceArea.X2];
-    Top    := [@InterfaceArea.Y1, 23];
-    Bottom := [@InterfaceArea.Y1, 51];
-    Center.MaxWidth := 119;
-  end;
-
-  with Self.Alignments[ERSXPBarLocation.RIGHT][ERSXPBarSize.SMALL] do
-  begin
-    Left := [@InterfaceArea.X2, -120];
-    Right := [@InterfaceArea.X2, -2];
-    Top := [@InterfaceArea.Y1, 0];
-    Bottom := [@InterfaceArea.Y1, 28];
-  end;
-
-  // Medium Text
-  with Self.Alignments[ERSXPBarLocation.LEFT][ERSXPBarSize.MEDIUM] do
-  begin
-    Left := [@InterfaceArea.X1, 2];
-    Right := [@InterfaceArea.X1, 130];
-    Top := [@InterfaceArea.Y1, 23];
-    Bottom := [@InterfaceArea.Y1, 51];
-  end;
-
-  with Self.Alignments[ERSXPBarLocation.MIDDLE][ERSXPBarSize.MEDIUM] do
-  begin
-    Left   := [@InterfaceArea.X1];
-    Right  := [@InterfaceArea.X2];
-    Top    := [@InterfaceArea.Y1, 23];
-    Bottom := [@InterfaceArea.Y1, 51];
-    Center.MaxWidth := 129;
-  end;
-
-  with Self.Alignments[ERSXPBarLocation.RIGHT][ERSXPBarSize.MEDIUM] do
-  begin
-    Left := [@InterfaceArea.X2, -130];
-    Right := [@InterfaceArea.X2, -2];
-    Top := [@InterfaceArea.Y1, 0];
-    Bottom := [@InterfaceArea.Y1, 28];
-  end;
-
-  // Large Text
-  with Self.Alignments[ERSXPBarLocation.LEFT][ERSXPBarSize.LARGE] do
+  with Self.Alignments[0] do
   begin
     Left := [@InterfaceArea.X1, 2];
     Right := [@InterfaceArea.X1, 141];
@@ -79,7 +40,7 @@ begin
     Bottom := [@InterfaceArea.Y1, 51];
   end;
 
-  with Self.Alignments[ERSXPBarLocation.MIDDLE][ERSXPBarSize.LARGE] do
+  with Self.Alignments[1] do
   begin
     Left   := [@InterfaceArea.X1];
     Right  := [@InterfaceArea.X2];
@@ -88,7 +49,7 @@ begin
     Center.MaxWidth := 140;
   end;
 
-  with Self.Alignments[ERSXPBarLocation.RIGHT][ERSXPBarSize.LARGE] do
+  with Self.Alignments[2] do
   begin
     Left := [@InterfaceArea.X2, -141];
     Right := [@InterfaceArea.X2, -2];
@@ -97,59 +58,158 @@ begin
   end;
 end;
 
-procedure TRSXPBar.SetupAlignment(Mode: ERSClientMode); override;
-begin
-  inherited;
+(*
+XPBar.IsEnabled
+~~~~~~~~~~~~~~~
+.. pascal:: function TRSXPBar.IsEnabled(): Boolean;
 
-  // Default location & size
-  Self.Alignment := Self.Alignments[ERSXPBarLocation.RIGHT][ERSXPBarSize.SMALL];
-  Self.Font := RS_FONT_PLAIN_11;
+Checks if the XPBar circle is enabled.
+
+Example
+-------
+
+  WriteLn XPBar.IsEnabled();
+*)
+function TRSXPBar.IsEnabled(): Boolean;
+var
+  TPA: TPointArray;
+begin
+  if FindColors(TPA, 11592943, Minimap.GetXPCircle.Bounds) then
+    Result := Length(Minimap.GetXPCircle().Filter(TPA)) > 50;
 end;
 
-function TRSXPBar.IsOpen: Boolean;
+(*
+XPBar.Enable
+~~~~~~~~~~~~
+.. pascal:: function TRSXPBar.Enable(): Boolean;
 
-  function FindBorder: Boolean;
-  const
-    COLOR_BORDER = $233038;
-  begin
-    Result := SRL.CountColor(COLOR_BORDER, Self.Bounds) = (Self.Width*2 + Self.Height*2) - 4;
-  end;
+Enables the XPBar by clicking the XPBar circle.
 
-  function UpdateLocation: Boolean;
-  var
-    Location: ERSXPBarLocation;
-    Size: ERSXPBarSize;
-  begin
-    for Location in ERSXPBarLocation do
-      for Size in ERSXPBarSize do
-      begin
-        Self.Cache := [];
-        Self.Alignment := Self.Alignments[Location][Size];
-        if FindBorder() then
-        begin
-          case Size of
-            ERSXPBarSize.SMALL:  Self.Font := RS_FONT_PLAIN_11;
-            ERSXPBarSize.MEDIUM: Self.Font := RS_FONT_PLAIN_12;
-            ERSXPBarSize.LARGE:  Self.Font := RS_FONT_BOLD_12;
-          end;
+Example
+-------
 
-          Exit(True);
-        end;
-      end;
-  end;
-
+  if not XPBar.IsEnabled() then
+    WriteLn XPBar.Enable();
+*)
+function TRSXPBar.Enable(): Boolean;
 begin
-  Result := FindBorder() or UpdateLocation();
-end;
-
-function TRSXPBar.Open: Boolean;
-begin
-  if Self.IsOpen then
+  if Self.IsEnabled() then
     Exit(True);
 
   Mouse.Click(Minimap.GetXPCircle(), MOUSE_LEFT);
 
+  Result := WaitUntil(Self.IsEnabled(), SRL.TruncatedGauss(100, 1000), 3000);
+end;
+
+(*
+XPBar._Setup
+~~~~~~~~~~~~
+.. pascal:: procedure TRSXPBar._Setup();
+
+Internal method automatically called by SRL once when attempting to read the XPBar.
+*)
+procedure TRSXPBar._Setup();
+var
+  tpa: TPointArray;
+  b: TBox;
+begin
+  if not Self.Enable() then
+    Exit;
+
+  for Self.Alignment in Self.Alignments do
+  begin
+    if SRL.FindColors(tpa, $FFFFFF, Self.Bounds()) > 0 then
+      Break;
+    Self.Cache := [];
+  end;
+
+  if tpa = [] then
+  begin
+    Self.Alignment := [];
+    Self.Cache := [];
+    Self.Font := [];
+    Exit;
+  end;
+
+  case tpa.Bounds().Height() of
+    8:  Self.Font := RS_FONT_PLAIN_11;
+    11: Self.Font := RS_FONT_PLAIN_12;
+    10: Self.Font := RS_FONT_BOLD_12; //it's actually less tall lol.
+    else
+    begin
+      Self.Alignment := [];
+      Self.Cache := [];
+      Self.Font := [];
+      Exit;
+    end;
+  end;
+
+  Self.IsSetup := True;
+end;
+
+(*
+XPBar.Read
+~~~~~~~~~~
+.. pascal:: function TRSXPBar.Read(): Int32;
+
+Reads the XP in the XPBar.
+
+Example
+-------
+
+  WriteLn XPBar.Read();
+*)
+function TRSXPBar.Read(): Int32;
+begin
+  if not Self.IsSetup then
+    Self._Setup();
+
+  //Self._Setup() already checks Self.IsEnabled() but it's only called once.
+  if not Self.IsSetup or not Self.Enable() then
+    Exit;
+
+  Result := OCR.RecognizeNumber(Self.Bounds(), TOCRColorRule.Create([$FFFFFF]), Self.Font);
+end;
+
+(*
+XPBar.IsOpen
+~~~~~~~~~~~~
+.. pascal:: function TRSXPBar.IsOpen(): Boolean;
+
+Checks if the XPBar is open.
+Keep in mind interfaces and things that cover the xp bar, might make this return false.
+
+Example
+-------
+
+  WriteLn XPBar.IsOpen();
+*)
+function TRSXPBar.IsOpen(): Boolean;
+begin
+  Result := Self.Read() > 0;
+end;
+
+(*
+XPBar.Open
+~~~~~~~~~~
+.. pascal:: function TRSXPBar.Open(): Boolean;
+
+Attempts to open the XPBar if it's not open.
+
+Example
+-------
+  if not XPBar.IsOpen() then
+    WriteLn XPBar.Open();
+*)
+function TRSXPBar.Open(): Boolean;
+begin
+  if Self.IsOpen() then
+    Exit(True);
+
   Result := WaitUntil(Self.IsOpen(), SRL.TruncatedGauss(100, 1000), 3000);
+
+  if not Result then
+    Self.DebugLn('Something is wrong with your XPBar.');
 end;
 
 procedure TRSXPBar.Draw(Bitmap: TMufasaBitmap); override;
@@ -160,25 +220,22 @@ begin
   inherited;
 end;
 
-function TRSXPBar.Read: Int32;
-begin
-  Result := -1;
-
-  if Self.IsOpen() then
-    Result := OCR.RecognizeNumber(Self.Bounds, TOCRColorRule.Create([$FFFFFF]), Self.Font);
-end;
-
+(*
+var XPBar
+~~~~~~~~~
+  Global XPBar variable.
+*)
 var
   XPBar: TRSXPBar;
 
-procedure TRSClient.ClientModeChanged; override;
+procedure TRSClient.ClientModeChanged(); override;
 begin
   inherited;
 
   XPBar.SetupAlignment(Self.Mode);
 end;
 
-procedure TSRL.Setup; override;
+procedure TSRL.Setup(); override;
 begin
   inherited;
 

--- a/utils.simba
+++ b/utils.simba
@@ -5,6 +5,9 @@ type
     IsSetup: Boolean;
   end;
 
+const
+  DATAPATH = AppPath + 'Data' + DirectorySeparator; //missing this const and walker1500 needs it.
+
 var
   SRL: TSRL;
 

--- a/utils/drawing.simba
+++ b/utils/drawing.simba
@@ -9,6 +9,9 @@ Drawing
 Extends TMufasaBitmap with mostly drawing functions.
 *)
 
+type
+  TMufasaBitmapArray = array of TMufasaBitmap;
+
 const
   clBlack      = Int32($000000);
   clMaroon     = Int32($000080);

--- a/utils/tboxarrays.simba
+++ b/utils/tboxarrays.simba
@@ -338,3 +338,96 @@ begin
     Result[I].Y2 := Result[I].Y1 + Height;
   end;
 end;
+
+function TBoxArray.Pack: TBoxArray;
+type
+  TBlock = record X,Y,W,H: Integer; Index: Integer; end;
+  TBlockArray = array of TBlock;
+
+  function Block(X,Y,W,H: Integer; Index: Integer = -1): TBlock;
+  begin
+    Result.X := X;
+    Result.Y := Y;
+    Result.W := W;
+    Result.H := H;
+    Result.Index := Index;
+  end;
+var
+  weights: TIntegerArray;
+  I, J: Integer;
+  StartWidth, Area, MaxWidth: Integer;
+  Width, Height: Integer;
+  Blocks, Spaces: TBlockArray;
+  Len: Integer;
+begin
+  Len := Length(Self);
+  if (Len = 0) then
+    Exit(Default(TBoxArray));
+
+  Area := 0;
+  MaxWidth := 0;
+
+  SetLength(Result, Len);
+  SetLength(Blocks, Len);
+  SetLength(Weights, Len);
+
+  for I := 0 to Len - 1 do
+  begin
+    Blocks[I] := Block(0, 0, Self[I].Width - 1, Self[I].Height - 1, I);
+    Weights[I] := Blocks[I].H;
+
+    Area += Blocks[I].W * Blocks[I].H;
+    MaxWidth := Max(MaxWidth, Blocks[I].W);
+  end;
+
+  Blocks := Sorted(Blocks, Weights, False);
+
+  StartWidth := Max(Ceil(Sqrt(Area / 0.95)), MaxWidth);
+  Spaces := [Block(0, 0, StartWidth, $FFFFFF)];
+
+  Width := 0;
+  Height := 0;
+
+  for I := 0 to Len - 1 do
+    for J := High(Spaces) downto 0 do
+    begin
+      if (Blocks[I].W > Spaces[J].W) or (Blocks[I].H > Spaces[J].H) then
+        Continue;
+
+      Blocks[I].X := Spaces[J].X;
+      Blocks[I].Y := Spaces[J].Y;
+
+      Width  := Max(Width, Blocks[I].X + Blocks[I].W);
+      Height := Max(Height, Blocks[I].Y + Blocks[I].H);
+
+      if (Blocks[I].W = Spaces[J].W) and (Blocks[I].H = Spaces[J].H) then
+        Delete(Spaces, J, 1)
+      else
+      if (Blocks[I].H = Spaces[J].H) then
+      begin
+        Spaces[J].X += Blocks[I].W;
+        Spaces[J].W -= Blocks[I].W;
+      end else
+      if (Blocks[I].W = Spaces[J].W) then
+      begin
+        Spaces[J].Y += Blocks[I].H;
+        Spaces[J].H -= Blocks[I].H;
+      end else
+      begin
+        Spaces += [Block(
+          Spaces[J].X + Blocks[I].W,
+          Spaces[J].Y,
+          Spaces[J].W - Blocks[I].W,
+          Blocks[I].H
+        )];
+        Spaces[J].Y += Blocks[I].H;
+        Spaces[J].H -= Blocks[I].H;
+      end;
+
+      Break;
+    end;
+
+  for I := 0 to Len - 1 do
+    Result[Blocks[I].Index] := Box(Blocks[I].X, Blocks[I].Y, Blocks[I].X + Blocks[I].W, Blocks[I].Y + Blocks[I].H);
+end;
+


### PR DESCRIPTION
Current XPBar has a lot of issues:
- Because it's position and size are never permanent, there are situation where they are set wrong and then reading it fails.
- It also doesn't work with progress bar enabled which should be optional.
- Large uptexts in fixed mode can make SRL think the xpbar is not open.

This rework fixes all those. It also allows reading when is partially covered, which can be seen as a good or bad thing but I think it's fine and should be handled by the user.

Also adeed some utilities that will be required by the next PRs.