### PR TITLE
refactor: caching proposal

### DIFF
--- a/osr/gametabs.simba
+++ b/osr/gametabs.simba
@@ -4,7 +4,9 @@
 {$ENDIF}
 
 type
-  TRSGameTabs = type TRSInterface;
+  TRSGameTabs = record(TRSInterface)
+    TabBoxes: TBoxArray;
+  end;
 
   ERSGameTab = (
     COMBAT,
@@ -56,14 +58,15 @@ begin
     Result += 36;
 end;
 
-function TRSGameTabs.GetTabBoxes: TBoxArray;
+function TRSGameTabs.GetTabBoxes(): TBoxArray;
 var
   I: Int32;
 begin
+  if Self.TabBoxes = [] then
   case Self.Mode of
     ERSClientMode.FIXED, ERSClientMode.RESIZABLE_CLASSIC:
       begin
-        Result := Grid(7, 2, 30, 33, [3, 265], [Self.X1 + 6, Self.Y1 + 1]);
+        Self.TabBoxes := Grid(7, 2, 30, 33, [3, 265], [Self.X1 + 6, Self.Y1 + 1]);
       end;
 
     ERSClientMode.RESIZABLE_MODERN:
@@ -71,18 +74,20 @@ begin
         // One row
         if (RootInterface.Width >= 948) then
         begin
-          Result := Grid(14, 1, 30, 33, [3, 0], [Self.X1 - 197, Self.Y2 - 70]);
+          Self.TabBoxes := Grid(14, 1, 30, 33, [3, 0], [Self.X1 - 197, Self.Y2 - 70]);
           for I := Ord(ERSGameTab.MUSIC) downto Ord(ERSGameTab.FRIENDS) - 1 do
-            Result[I] := Result[I-1];
+            Self.TabBoxes[I] := Self.TabBoxes[I-1];
         end else
         // Two rows
-          Result := Grid(7, 2, 30, 33, [3, 3], [Self.X1, Self.Y2 - 70]);
+          Self.TabBoxes := Grid(7, 2, 30, 33, [3, 3], [Self.X1, Self.Y2 - 70]);
 
         // Logout button is moved to top right corner
-        Result[7] := Result[10];
-        Result[10] := [RootInterface.X2 - 19, RootInterface.Y1 + 9, RootInterface.X2 - 10, RootInterface.Y1 + 18];
+        Self.TabBoxes[7] := Self.TabBoxes[10];
+        Self.TabBoxes[10] := [RootInterface.X2 - 19, RootInterface.Y1 + 9, RootInterface.X2 - 10, RootInterface.Y1 + 18];
       end;
   end;
+
+  Result := Self.TabBoxes;
 end;
 
 function TRSGameTabs.GetTabBox(Tab: ERSGameTab): TBox;
@@ -169,6 +174,8 @@ begin
         Self.Alignment.Bottom := [@RootInterface.Y2];
       end;
   end;
+
+  Self.TabBoxes := [];
 end;
 
 var

--- a/osr/inventory.simba
+++ b/osr/inventory.simba
@@ -27,18 +27,17 @@ const
 
 type
   TRSInventory = record(TRSInterface)
-    LOW_SLOT: Int32;
-    HIGH_SLOT: Int32;
+    SlotBoxes: TBoxArray;
+  class const
+    LOW_SLOT: Int32 = 0;
+    HIGH_SLOT: Int32 = 27;
   end;
 
-procedure TRSInventory.Setup; override;
+procedure TRSInventory.Setup(); override;
 begin
   inherited;
 
   Self.Name := 'Inventory';
-
-  Self.LOW_SLOT := 0;
-  Self.HIGH_SLOT := 27;
 end;
 
 procedure TRSInventory.SetupAlignment(Mode: ERSClientMode); override;
@@ -49,6 +48,7 @@ begin
   Self.Alignment.Right := [@GameTab.X2];
   Self.Alignment.Top := [@GameTab.Y1];
   Self.Alignment.Bottom := [@GameTab.Y2];
+  Self.SlotBoxes := []; //make sure the slotboxes cache is reset if the aligment changed.
 end;
 
 (*
@@ -100,7 +100,10 @@ Example
 *)
 function TRSInventory.GetSlotBoxes(): TBoxArray;
 begin
-  Result := Grid(4, 7, 31, 31, [11, 5], [Self.X1 + 13, Self.Y1 + 9]);
+  if Self.SlotBoxes = [] then
+    Self.SlotBoxes := Grid(4, 7, 31, 31, [11, 5], [Self.X1 + 13, Self.Y1 + 9]);
+
+  Result := Self.SlotBoxes;
 end;
 
 (*

--- a/osr/magic.simba
+++ b/osr/magic.simba
@@ -14,7 +14,8 @@ type
     STANDARD,
     ANCIENT,
     LUNAR,
-    ARCEUUS
+    ARCEUUS,
+    UNKNOWN
   );
 
   ERSSpell = (
@@ -310,7 +311,10 @@ const
     ERSSpell.SENNTISTEN_TELEPORT]);
   
 type
-  TRSMagic = type TRSInterface;
+  TRSMagic = record (TRSInterface)
+    SpellBook: ERSSpellBook;
+    SpellBoxes: TBoxArray;
+  end;
 
 (*
 Magic.Setup
@@ -326,6 +330,7 @@ begin
   inherited;
   
   Self.Name := 'Magic';
+  Self.SpellBook := ERSSpellBook.UNKNOWN;
 end;
 
 (*
@@ -345,6 +350,7 @@ begin
   Self.Alignment.Right := [@GameTab.X2];
   Self.Alignment.Top := [@GameTab.Y1];
   Self.Alignment.Bottom := [@GameTab.Y2];
+  Self.SpellBoxes := []; //reset cache on aligment change.
 end;
 
 (*
@@ -384,7 +390,7 @@ end;
 (*
 Magic.GetSpellBook
 ~~~~~~~~~~~~~~~~~~
-.. pascal:: function TRSMagic.GetSpellBook: ERSSpellBook;
+.. pascal:: function TRSMagic.GetSpellBook(forceCheck: Boolean = False): ERSSpellBook;
 
 Returns the current spell book.
 
@@ -393,17 +399,27 @@ Example
 
   WriteLn Magic.GetSpellBook;
 *)
-function TRSMagic.GetSpellBook: ERSSpellBook;
+function TRSMagic.GetSpellBook(forceCheck: Boolean = False): ERSSpellBook;
 const
   ARCEUUS_COLOR := CTS1(9801276, 78); // Colors of the book on the gametab
   ANCIENT_COLOR := CTS1(8077142, 28);
   LUNAR_COLOR   := CTS1(12761525, 27);
 var
-  Box: TBox := Gametabs.GetTabBox(ERSGameTab.MAGIC); 
+  Box: TBox;
 begin
-  if SRL.CountColor(ARCEUUS_COLOR, Box) >= 85 then Exit(ERSSpellBook.ARCEUUS);
-  if SRL.CountColor(ANCIENT_COLOR, Box) >= 85 then Exit(ERSSpellBook.ANCIENT);
-  if SRL.CountColor(LUNAR_COLOR,   Box) >= 85 then Exit(ERSSpellBook.LUNAR);
+  if forceCheck then
+    Self.SpellBook := ERSSpellBook.UNKNOWN;
+
+  if (Self.SpellBook = ERSSpellBook.UNKNOWN) then
+  begin
+    Box := Gametabs.GetTabBox(ERSGameTab.MAGIC);
+    if SRL.CountColor(ARCEUUS_COLOR, Box) >= 85 then Self.SpellBook := ERSSpellBook.ARCEUUS
+    else if SRL.CountColor(ANCIENT_COLOR, Box) >= 85 then Self.SpellBook := ERSSpellBook.ANCIENT
+    else if SRL.CountColor(LUNAR_COLOR,   Box) >= 85 then Self.SpellBook := ERSSpellBook.LUNAR
+    else Self.SpellBook := ERSSpellBook.STANDARD;
+  end;
+
+  Result := Self.SpellBook;
 end;
 
 (*
@@ -430,15 +446,19 @@ Magic.GetSpellBoxes
 
 Internal function to get the bounds of the spells of the current spell book.
 *)
-function TRSMagic.GetSpellBoxes(out Spellbook: ERSSpellBook): TBoxArray;
-begin 
-  Spellbook := Self.GetSpellBook;
-  case Spellbook of
-    ERSSpellBook.STANDARD: Result := Grid(7, 10, 23, 23, [3, 1],   [Self.X1 + 2, Self.Y1 + 1]);
-    ERSSpellBook.ARCEUUS:  Result := Grid(5, 9,  23, 23, [17, 4],  [Self.X1, Self.Y1 + 1]);
-    ERSSpellBook.LUNAR:    Result := Grid(5, 9,  23, 23, [17, 4],  [Self.X1 + 2, Self.Y1 + 1]);
-    ERSSpellBook.ANCIENT:  Result := Grid(4, 7,  23, 23, [25, 13], [Self.X1 + 8, Self.Y1 + 1]);
-  end;
+function TRSMagic.GetSpellBoxes(out CurrentSpellbook: ERSSpellBook): TBoxArray;
+begin
+  CurrentSpellbook := Self.GetSpellBook();
+
+  if Self.SpellBoxes = [] then
+    case Spellbook of
+      ERSSpellBook.STANDARD: Self.SpellBoxes := Grid(7, 10, 23, 23, [3, 1],   [Self.X1 + 2, Self.Y1 + 1]);
+      ERSSpellBook.ARCEUUS:  Self.SpellBoxes := Grid(5, 9,  23, 23, [17, 4],  [Self.X1, Self.Y1 + 1]);
+      ERSSpellBook.LUNAR:    Self.SpellBoxes := Grid(5, 9,  23, 23, [17, 4],  [Self.X1 + 2, Self.Y1 + 1]);
+      ERSSpellBook.ANCIENT:  Self.SpellBoxes := Grid(4, 7,  23, 23, [25, 13], [Self.X1 + 8, Self.Y1 + 1]);
+    end;
+
+  Result := Self.SpellBoxes;
 end;
 
 (*


### PR DESCRIPTION
This is just a small proposal of a cache implementation. The benefits are very tiny but some of this methods are used extremely often and the changes are, in my opinion also very minimal. This is just a proposal, this could be implemented in many other interfaces, some with more benefits than others.

Some benchmarks I ran (new vs old):
```
TRSInventory.GetSlotBoxes():
Average runtime of 100000 iterations: 0.000786459999978542ms vs 0.0524685339999944ms.
Method one is 194.093% faster than method two.

TRSGameTabs.GetTabBoxes() Fixed:
Average runtime of 100000 iterations: 0.000806550999991596ms vs 0.0330575460000336ms.
Method one is 190.473% faster than method two.   

TRSGameTabs.GetTabBoxes() Resizable Modern:
Average runtime of 100000 iterations: 0.00102746800001711ms vs 0.0856203500000015ms.
Method one is 195.257% faster than method two.

TRSMagic.GetSpellBook() (Without including the changes to TRSGameTabs.GetTabBoxes() which would sum to this):
Average runtime of 100000 iterations: 0.00093359999999404ms vs 1.62406020299997ms.
Method one is 199.77% faster than method two. 

TRSMagic.GetSpellBoxes()  (Without including the changes to TRSMagic.GetSpellBook() which would sum to this):
Average runtime of 100000 iterations: 0.00166463399998844ms vs 0.000876030999943614ms.
Method one is 62.078% faster than method two. 
```