### PR TITLE
fix: read comments

### DIFF
--- a/utils/tpointarrays.simba
+++ b/utils/tpointarrays.simba
@@ -1377,20 +1377,44 @@ begin
     Result[i] := GetTPABounds(Self[i]);
 end;
 
+
+function T2DPointArray.First(): TPointArray; constref;
+begin
+  if Self <> [] then
+    Result := Self[0];
+end;
+
+function T2DPointArray.Last(): TPointArray; constref;
+begin
+  if Self <> [] then
+    Result := Self[High(Self)];
+end;
+ 
+
 function T2DPointArray.Smallest(): TPointArray; constref;
 var
-  TPA: TPointArray;
+  tpa: TPointArray;
 begin
-  for TPA in Self do
-    if (Length(TPA) < Length(Result)) then
-      Result := TPA;
+  for tpa in Self do
+  begin
+    if Result = [] then
+      Result := tpa;
+
+    if (Length(tpa) < Length(Result)) then
+      Result := tpa;
+  end;
 end;
 
 function T2DPointArray.Biggest(): TPointArray; constref;
 var
-  TPA: TPointArray;
+  tpa: TPointArray;
 begin
-  for TPA in Self do
-    if (Length(TPA) > Length(Result)) then
-      Result := TPA;
+  for tpa in Self do
+  begin
+    if Result = [] then
+      Result := tpa;
+
+    if (Length(tpa) > Length(Result)) then
+      Result := tpa;
+  end;
 end;


### PR DESCRIPTION
- `T2DPointArray.Smallest()` and `T2DPointArray.Biggest()` don't return an empty TPointArray anymore.
- Also added .First() and .Last() methods