### PR TITLE
fix: Make.IsOpen() in the world switcher

### DIFF
--- a/osr/make.simba
+++ b/osr/make.simba
@@ -82,15 +82,15 @@ Example
 *)
 function TRSMake.GetItemButtons(): TRSButtonArray;
 var
-  Button: TRSButton;
+  button: TRSButton;
   i: Int32;
 begin
-  for Button in Self.FindButtons([[0,0]]) do
-    if (Button.Bounds.Height > 60) and (Button.Bounds.Width > 20) then
-      Result += Button;
-
-  for i := 0 to High(Result) do  //Fixes buttons indexes!
-    Result[i].Index := i;
+  for button in Self.FindButtons([[0,0]]) do
+    if InRange(button.Bounds.Height(), 60, 85) and InRange(button.Bounds.Width(), 20, 120) then
+    begin
+      button.Index := Length(Result);
+      Result += button;
+    end;
 end;
 
 (*


### PR DESCRIPTION
The make menu was coming up as true in the world switcher. Not a big deal but I added some width and height limits to stop it from happening.

I don't know exactly what's the true upper limits because they vary from task to task and I can't try them all so I set it to something that felt reasonable.

Also removed the second loop of the method which wasn't required at all